### PR TITLE
Add vCPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ I, [2018-08-12T20:54:37.560003 #64341]  INFO -- : Finished: host2
 +---------------+-------------+-------------|-------+
 | instance_type |    t2.micro |  c4.2xlarge |   N/A |
 |   instance_id |  i-xxxxxxxx |  i-yyyyyyyy |   N/A |
-|        memory |   1016324kB |  15395932kB |   N/A |
+|          vCPU |           1 |           8 |   N/A |
+|        memory |       1 GiB |      15 GiB |   N/A |
 | price (USD/H) |      0.0152 |       0.504 |   N/A |
 | price (USD/M) |     11.3088 |     374.976 |   N/A |
 +---------------+-------------+---------------------+
@@ -73,7 +74,7 @@ I, [2018-08-12T20:54:25.814752 #64341]  INFO -- : Started: host1
 I, [2018-08-12T20:54:25.814835 #64341]  INFO -- : Started: host2
 I, [2018-08-12T20:54:29.385848 #64341]  INFO -- : Finished: host1
 I, [2018-08-12T20:54:37.560003 #64341]  INFO -- : Finished: host2
-=> {"host1":{"instance_type":"t2.micro","instance_id":"i-xxxxxxxx","memory":"1016324kB","price (USD/H)":0.152,"price (USD/M)":11.3088},"host2":{"instance_type":"c4.2xlarge","instance_id":"i-yyyyyyyy","memory":"15395932kB","price (USD/H)":0.504,"price (USD/M)":374.976}}
+=> {"host1":{"instance_type":"t2.micro","instance_id":"i-xxxxxxxx","vCPU":"1","memory":"1 GiB","price (USD/H)":0.152,"price (USD/M)":11.3088},"host2":{"instance_type":"c4.2xlarge","instance_id":"i-yyyyyyyy","vCPU":"8","memory":"15 GiB","price (USD/H)":0.504,"price (USD/M)":374.976}}
 ```
 
 ## Requirement

--- a/lib/ec2spec/client.rb
+++ b/lib/ec2spec/client.rb
@@ -57,7 +57,6 @@ module Ec2spec
       begin
         host.instance_type = instance_type(backend)
         host.instance_id   = instance_id(backend)
-        host.memory = memory(backend)
       rescue Errno::ECONNREFUSED
         host.na_values
       end
@@ -86,10 +85,6 @@ module Ec2spec
 
     def instance_id_cmd
       "curl -s #{metadata_url(META_DATA_INSTANCE_ID_PATH)}"
-    end
-
-    def memory(backend)
-      Specinfra::HostInventory::Memory.new(backend.host_inventory).get['total']
     end
 
     def target(host_name)

--- a/lib/ec2spec/host_result.rb
+++ b/lib/ec2spec/host_result.rb
@@ -6,12 +6,13 @@ module Ec2spec
     LABEL_WITH_METHODS = {
       'instance_type' => :instance_type,
       'instance_id'   => :instance_id,
+      'vCPU'          => :vcpu,
       'memory'        => :memory,
       'price (USD/H)' => :price_per_unit,
       'price (USD/M)' => :price_per_month,
     }
 
-    attr_accessor :host, :backend, :instance_id, :memory, :cpu
+    attr_accessor :host, :backend, :instance_id, :cpu
     attr_reader :instance_type
     attr_writer :price_per_unit
 
@@ -35,6 +36,16 @@ module Ec2spec
 
       return if value == NA_VALUE
       price_per_unit
+    end
+
+    def vcpu
+      @vcpu ||=
+        Ec2spec::OfferFile.instance.vcpu(@instance_type)
+    end
+
+    def memory
+      @memory ||=
+        Ec2spec::OfferFile.instance.memory(@instance_type)
     end
 
     def price_per_unit

--- a/lib/ec2spec/offer_file.rb
+++ b/lib/ec2spec/offer_file.rb
@@ -18,6 +18,22 @@ module Ec2spec
       end
     end
 
+    def products
+      offer_file_json['products']
+    end
+
+    def vcpu(instance_type)
+      sku_instance_type = sku(instance_type)
+      product = products[sku_instance_type]['attributes']
+      product['vcpu']
+    end
+
+    def memory(instance_type)
+      sku_instance_type = sku(instance_type)
+      product = products[sku_instance_type]['attributes']
+      product['memory']
+    end
+
     def price_per_unit(instance_type)
       sku_instance_type = sku(instance_type)
       on_demand = offer_file_json['terms']['OnDemand']
@@ -49,7 +65,6 @@ module Ec2spec
     end
 
     def sku(instance_type)
-      products = offer_file_json['products']
       target_product = products.find do |product|
         product?(product, instance_type)
       end


### PR DESCRIPTION
Add vCPU and memory values from Price List API.

For example:
```
+---------------+-------------+-------------+-------+
|               | host1       | host2       | host3 |
+---------------+-------------+-------------|-------+
| instance_type |    t2.micro |  c4.2xlarge |   N/A |
|   instance_id |  i-xxxxxxxx |  i-yyyyyyyy |   N/A |
|          vCPU |           1 |           8 |   N/A |
|        memory |       1 GiB |      15 GiB |   N/A |
| price (USD/H) |      0.0152 |       0.504 |   N/A |
| price (USD/M) |     11.3088 |     374.976 |   N/A |
+---------------+-------------+---------------------+
```